### PR TITLE
Added makefile for easier access to the docker  start and stop and other commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,17 +90,18 @@ To run the FreeAPI project, follow these steps:
 2. Clone the project repository.
 3. Navigate to the project directory.
 4. Create `.env` file in the root folder and copy paste the content of `.env.sample`, and add necessary credentials.
-5. Run the Docker Compose command:
+5. Run the command: ``` make docker-start ```
 
-```bash
-docker-compose up --build --attach backend
+   OR if you want to run the Docker Compose manually, run
+   ```bash
+   docker-compose up --build --attach backend
 
-# --build: Rebuild the image and run the containers
-# --attach: only show logs of Node app container and not mongodb
-```
+   # --build: Rebuild the image and run the containers
+   # --attach: only show logs of Node app container and not mongodb
+   ```
 
 6. Access the project APIs at the specified endpoints.
-
+7. To stop and remove the Docker containers, run ``` make docker-stop ``` which is quivalent of ```docker-compose down```, as preferred
 ### 💻 Running locally
 
 To run the FreeAPI project locally, follow these steps:

--- a/makefile
+++ b/makefile
@@ -1,0 +1,5 @@
+docker-start:
+	docker-compose up --build --attach backend
+
+docker-stop:
+	docker-compose down


### PR DESCRIPTION
This pull request simplifies the process of running the code by adding a Makefile. Previously, users had to run the Docker Compose multiple times. With this addition, running ```make docker-start``` starts up the Docker containers, and 
```make docker-stop``` brings them down, streamlining the workflow. This improvement enhances code maintainability and user experience.