### PR TITLE
docs: Single click to deploy on railway app for self-hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,40 @@ yarn start
 
 6. Access the project APIs at the specified endpoints.
 
+### 🚄 Using Railway (One-click Deploy)
+
+To have a self-hosting of the FreeAPI.app application you can take advantage of pre-built template that is readily available
+
+[![Deploy FreeAPI.app](https://railway.app/button.svg)](https://railway.app/template/B2f7Hq)
+
+1. Click on the below button to visit railway.app
+
+2. Click on **Deploy Now** button
+
+3. (Optional) Sign in with GitHub to Deploy
+
+4. To fill in Repository details:
+   - Specify the repo name (ex. freeapi-app)
+   - Checkmark for Pubic/Private repository
+
+5. To fill in Environment variables, we have provided some default values in the `ENV` to reduce the burden. But some parameters are mandatory
+   - `PORT`: Don't change the value, let it be set to 8080 inorder to view the swagger docs after deployment
+   - `MONGODB_URI`: Provide the mongodb atlas database URL. An example is prefilled for you, edit/update to continue
+   - `NODE_ENV`: Default set to 'development' inorder to view the logs. You may choose to change to anyother value such as 'prod' to hide them
+   - `EXPRESS_SESSION_SECRET`: Advised to change the default value to your own secret value
+   - `ACCESS_TOKEN_SECRET`: Advised to change the default value to your own secret value
+   - `ACCESS_TOKEN_EXPIRY`: Set to 1 day as default
+   - `REFRESH_TOKEN_SECRET`: Advised to change the default value to your own secret value
+   - `REFRESH_TOKEN_EXPIRY`: Set to 10 days as default
+
+6. Once you fill in the required parameters of env, if you choose the add the others as such such as Paypal, Google & Razorpay please proceed to mention your credentials in the form
+
+7. Click on **Deploy** button to trigger the first build
+
+* Monitor the server logs, if you come across any deployment problems feel free to raise an issue for our team to look into.
+
+Note: Once the application is deployed please way for 3-5 mintues for the swagger docs to be available.
+
 # 📜 Swagger Docs
 
 [Swagger Docs](http://localhost:8080): http://localhost:8080

--- a/README.md
+++ b/README.md
@@ -125,37 +125,36 @@ yarn start
 
 ### 🚄 Using Railway (One-click Deploy)
 
-To have a self-hosting of the FreeAPI.app application you can take advantage of pre-built template that is readily available
+To self-host the FreeAPI.app application, you can take advantage of a pre-built template that is readily available.
 
 [![Deploy FreeAPI.app](https://railway.app/button.svg)](https://railway.app/template/B2f7Hq)
 
-1. Click on the below button to visit railway.app
+1. Click the button above to visit railway.app.
 
-2. Click on **Deploy Now** button
+2. Click on the **Deploy Now** button.
 
-3. (Optional) Sign in with GitHub to Deploy
+3. (Optional) Sign in with GitHub to deploy.
 
-4. To fill in Repository details:
-   - Specify the repo name (ex. freeapi-app)
-   - Checkmark for Pubic/Private repository
+4. Fill in the Repository details:
+   - Specify the repo name (e.g., freeapi-app).
+   - Checkmark for Public/Private repository.
 
-5. To fill in Environment variables, we have provided some default values in the `ENV` to reduce the burden. But some parameters are mandatory
-   - `PORT`: Don't change the value, let it be set to 8080 inorder to view the swagger docs after deployment
-   - `MONGODB_URI`: Provide the mongodb atlas database URL. An example is prefilled for you, edit/update to continue
-   - `NODE_ENV`: Default set to 'development' inorder to view the logs. You may choose to change to anyother value such as 'prod' to hide them
-   - `EXPRESS_SESSION_SECRET`: Advised to change the default value to your own secret value
-   - `ACCESS_TOKEN_SECRET`: Advised to change the default value to your own secret value
-   - `ACCESS_TOKEN_EXPIRY`: Set to 1 day as default
-   - `REFRESH_TOKEN_SECRET`: Advised to change the default value to your own secret value
-   - `REFRESH_TOKEN_EXPIRY`: Set to 10 days as default
+5. For Environment variables, we have provided some default values in the `ENV` to reduce the burden, but some parameters are mandatory:
+   - `PORT`: Do not change the value, let it be set to 8080 to view the swagger docs after deployment.
+   - `MONGODB_URI`: Provide the MongoDB Atlas database URL. An example is prefilled for you, edit/update it to continue.
+   - `NODE_ENV`: Default set to 'development' to view the logs. You may choose to change it to any other value such as 'prod' to hide them.
+   - `EXPRESS_SESSION_SECRET`: It is advised to change the default value to your own secret value.
+   - `ACCESS_TOKEN_SECRET`: It is advised to change the default value to your own secret value.
+   - `ACCESS_TOKEN_EXPIRY`: Set to 1 day as default.
+   - `REFRESH_TOKEN_SECRET`: It is advised to change the default value to your own secret value.
+   - `REFRESH_TOKEN_EXPIRY`: Set to 10 days as default.
 
-6. Once you fill in the required parameters of env, if you choose the add the others as such such as Paypal, Google & Razorpay please proceed to mention your credentials in the form
+6. Once you fill in the required environment parameters, if you choose to add others such as PayPal, Google, and Razorpay, please proceed to mention your credentials in the form.
 
-7. Click on **Deploy** button to trigger the first build
+7. Click on the **Deploy** button to trigger the first build.
+   - Monitor the server logs; if you come across any deployment problems, feel free to raise an issue for our team to look into.
 
-* Monitor the server logs, if you come across any deployment problems feel free to raise an issue for our team to look into.
-
-Note: Once the application is deployed please way for 3-5 mintues for the swagger docs to be available.
+Note: Once the application is deployed, please wait for 3-5 minutes for the swagger docs to be available.
 
 # 📜 Swagger Docs
 


### PR DESCRIPTION
Template: https://railway.app/template/B2f7Hq

## Description
1. Allows users of FreeApi.app to self-host
2. Takes advantage of Docker to build the image and host
3. On successful deployment the application live link would open to swagger docs

## Changes
1. Updated readme docs with steps