### PR TITLE
fix(issue #30): json module assertion issue for node version < 17.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "src/index.js",
   "scripts": {
-    "start": "nodemon -r dotenv/config src/index.js"
+    "start": "nodemon -r dotenv/config --experimental-json-modules src/index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Context
From Node.js version 17.5.0 onward, importing a JSON file is possible using [Import Assertions](https://nodejs.org/api/esm.html#json-modules):

## Possible Solution
According to the compatibility tables on MDN for [import declarations](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#browser_compatibility) and [dynamic import](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import#browser_compatibility), older versions of Node.js (16.0.0 – 16.14.0 and 17.0.0 – 17.4.0) had varying support:

These versions required the `--experimental-json-modules` flag:

```bash
nodemon -r dotenv/config --experimental-json-modules src/index.js
```