### PR TITLE
Fix the .env configure issue

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,6 @@
 import cookieParser from "cookie-parser";
 import cors from "cors";
+import dotenv from "dotenv";
 import express from "express";
 import { rateLimit } from "express-rate-limit";
 import session from "express-session";
@@ -21,6 +22,9 @@ const file = fs.readFileSync(path.resolve(__dirname, "./swagger.yaml"), "utf8");
 const swaggerDocument = YAML.parse(file);
 
 const app = express();
+
+// configure .env
+dotenv.config();
 
 // global middlewares
 app.use(


### PR DESCRIPTION
In certain devices, direct access to process environment variables using process.env.ENV_NAME is not functioning as expected. This could lead to errors and inconsistencies in our application when attempting to access configuration values from the .env file.

To address this issue I have implemented the dotenv configuration in app.js.