### PR TITLE
feat: add new API for deleting completed todos

### DIFF
--- a/src/controllers/apps/todo/todo.controllers.js
+++ b/src/controllers/apps/todo/todo.controllers.js
@@ -114,6 +114,23 @@ const deleteTodo = asyncHandler(async (req, res) => {
     );
 });
 
+const deleteCompletedTodo = asyncHandler(async (req, res) => {
+  const todos = await Todo.deleteMany({ isComplete: true });
+
+  if (!todos.deletedCount > 0) {
+    throw new ApiError(404, "No completed todos found to delete");
+  }
+  return res
+    .status(200)
+    .json(
+      new ApiResponse(
+        200,
+        { deletedCount: todos.deletedCount },
+        "Completed todos deleted successfully"
+      )
+    );
+});
+
 export {
   getAllTodos,
   getTodoById,
@@ -121,4 +138,5 @@ export {
   updateTodo,
   deleteTodo,
   toggleTodoDoneStatus,
+  deleteCompletedTodo,
 };

--- a/src/routes/apps/todo/todo.routes.js
+++ b/src/routes/apps/todo/todo.routes.js
@@ -2,6 +2,7 @@ import { Router } from "express";
 
 import {
   createTodo,
+  deleteCompletedTodo,
   deleteTodo,
   getAllTodos,
   getTodoById,
@@ -23,6 +24,8 @@ router
   .post(createTodoValidator(), validate, createTodo)
   .get(getAllTodosQueryValidators(), validate, getAllTodos);
 
+router.route("/completed").delete(deleteCompletedTodo);
+
 router
   .route("/:todoId")
   .get(mongoIdPathVariableValidator("todoId"), validate, getTodoById)
@@ -36,6 +39,10 @@ router
 
 router
   .route("/toggle/status/:todoId")
-  .patch(mongoIdPathVariableValidator("todoId"), validate, toggleTodoDoneStatus);
+  .patch(
+    mongoIdPathVariableValidator("todoId"),
+    validate,
+    toggleTodoDoneStatus
+  );
 
 export default router;


### PR DESCRIPTION
## Title
Add DELETE /todos/completed endpoint and include additional response data

## Pull Request Description

This PR adds a new API endpoint, ```DELETE /todos/completed```, to delete all completed todos and includes additional data in the response for improved user feedback. 

## Changes Made

- Added a new route handler for ```DELETE /todos/completed``` in ```todo.routes.js``` to delete completed todos.
- Included a ```deletedCount``` property in the response JSON to provide the number of completed todos deleted.
- Included a ```deletedCount``` property in the response JSON to provide the number of completed todos deleted.

## Checklist

- [✅] I have read the project's contribution guidelines.
- [✅] I have followed the project's coding style and guidelines.
- [✅] I have tested the new API thoroughly.
- [✅] My code builds without errors.

## Additional Comments

I'm open to feedback and happy to make further adjustments as needed. Thank you for considering my contribution!

Imtiyaz Nandasaniya
