### PR TITLE
fix: vite dev server option server.fs.deny can be bypassed

### DIFF
--- a/examples/apps/todo/web/react-vite-tailwind/package-lock.json
+++ b/examples/apps/todo/web/react-vite-tailwind/package-lock.json
@@ -28,7 +28,7 @@
         "postcss": "^8.4.33",
         "tailwindcss": "^3.4.1",
         "typescript": "^5.2.2",
-        "vite": "^5.0.8"
+        "vite": "^5.0.12"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4118,9 +4118,9 @@
       "dev": true
     },
     "node_modules/vite": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.11.tgz",
-      "integrity": "sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
+      "integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",

--- a/examples/apps/todo/web/react-vite-tailwind/package.json
+++ b/examples/apps/todo/web/react-vite-tailwind/package.json
@@ -30,6 +30,6 @@
     "postcss": "^8.4.33",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.2.2",
-    "vite": "^5.0.8"
+    "vite": "^5.0.12"
   }
 }


### PR DESCRIPTION
## Security alert

### Changes
- Upgrade of `vite` developer dependency as per [alert](https://github.com/hiteshchoudhary/apihub/security/dependabot/22)