### PR TITLE
fix: node version in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:18
 
 RUN mkdir -p /usr/src/freeapi && chown -R node:node /usr/src/freeapi
 


### PR DESCRIPTION
Hello @jwala-anirudh @hiteshchoudhary ,
This is a PR for [Issue #148] where there was an issue of Node version while installing via Docker. Thus changed the Node version 
to 18. The screenshot of the issue that i faced is  
![image](https://github.com/hiteshchoudhary/apihub/assets/67196176/646903d9-33fc-4b03-b70a-71a923bf61eb)

Please let me know if there's anything I should know about this.