### PR TITLE
fix(auth): properly clear refreshToken in database upon user logout

### DIFF
--- a/src/controllers/apps/auth/user.controllers.js
+++ b/src/controllers/apps/auth/user.controllers.js
@@ -168,7 +168,7 @@ const logoutUser = asyncHandler(async (req, res) => {
     req.user._id,
     {
       $set: {
-        refreshToken: undefined,
+        refreshToken: '',
       },
     },
     { new: true }


### PR DESCRIPTION
### Description

This PR addresses issue #147, where the `refreshToken` value in the database is not properly cleared when users log out. The bug occurs due to setting the `refreshToken` to `undefined`, which does not update the database as expected. 

### Changes Made:

It updates the logout endpoint to set the `refreshToken` to an empty string (`''`) instead of `undefined`, ensuring that it is correctly updated in the database when users log out.

### Testing:

- Manually tested logout functionality to verify successful clearing of refreshToken.
- Checked for any unintended side effects or regressions.

### Additional Notes:

- No changes to the existing API contract or external behavior are introduced by this fix.
- The code has been reviewed and follows the coding standards and conventions of the project.

### Related Issue:

- Issue #147

### Screenshots:

- **Login**
- 
  ![Logged in from Postman](https://github.com/hiteshchoudhary/apihub/assets/100425384/169e5c30-255b-464d-9eed-ebcab0d4046b)
![DB with refreshToken](https://github.com/hiteshchoudhary/apihub/assets/100425384/3cc38670-828a-47ea-abdc-101bc6cb70ff)

- **Logout**
-
   ![Logged out using Postman](https://github.com/hiteshchoudhary/apihub/assets/100425384/dedac4bc-2edb-4e59-86fc-e5311ab1d257)
![DB is cleared refreshToken](https://github.com/hiteshchoudhary/apihub/assets/100425384/61892946-104f-4dfb-b875-0fd615986de4)
