### PR TITLE
Resolved Compatabilities of assert keyword with node latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node
 
 RUN mkdir -p /usr/src/freeapi && chown -R node:node /usr/src/freeapi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:18-alpine
 
 RUN mkdir -p /usr/src/freeapi && chown -R node:node /usr/src/freeapi
 

--- a/src/controllers/kitchen-sink/statuscode.controllers.js
+++ b/src/controllers/kitchen-sink/statuscode.controllers.js
@@ -1,5 +1,5 @@
 import { asyncHandler } from "../../utils/asyncHandler.js";
-import statusCodesJson from "../../json/status-codes.json" assert { type: "json" };
+import statusCodesJson from "../../json/status-codes.json" with { type: "json" };
 import { ApiError } from "../../utils/ApiError.js";
 import { ApiResponse } from "../../utils/ApiResponse.js";
 

--- a/src/controllers/public/book.controllers.js
+++ b/src/controllers/public/book.controllers.js
@@ -1,4 +1,4 @@
-import booksJson from "../../json/books.json" assert { type: "json" };
+import booksJson from "../../json/books.json" with { type: "json" };
 import { filterObjectKeys, getPaginatedPayload } from "../../utils/helpers.js";
 import { ApiError } from "../../utils/ApiError.js";
 import { ApiResponse } from "../../utils/ApiResponse.js";

--- a/src/controllers/public/cat.controllers.js
+++ b/src/controllers/public/cat.controllers.js
@@ -1,4 +1,4 @@
-import catsJson from "../../json/cats.json" assert { type: "json" };
+import catsJson from "../../json/cats.json" with { type: "json" };
 import { filterObjectKeys, getPaginatedPayload } from "../../utils/helpers.js";
 import { ApiError } from "../../utils/ApiError.js";
 import { ApiResponse } from "../../utils/ApiResponse.js";

--- a/src/controllers/public/dog.controllers.js
+++ b/src/controllers/public/dog.controllers.js
@@ -1,4 +1,4 @@
-import dogsJson from "../../json/dogs.json" assert { type: "json" };
+import dogsJson from "../../json/dogs.json" with { type: "json" };
 import { filterObjectKeys, getPaginatedPayload } from "../../utils/helpers.js";
 import { ApiError } from "../../utils/ApiError.js";
 import { ApiResponse } from "../../utils/ApiResponse.js";

--- a/src/controllers/public/meal.controllers.js
+++ b/src/controllers/public/meal.controllers.js
@@ -1,4 +1,4 @@
-import mealsJson from "../../json/meals.json" assert { type: "json" };
+import mealsJson from "../../json/meals.json" with { type: "json" };
 import { filterObjectKeys, getPaginatedPayload } from "../../utils/helpers.js";
 import { ApiError } from "../../utils/ApiError.js";
 import { ApiResponse } from "../../utils/ApiResponse.js";

--- a/src/controllers/public/quote.controllers.js
+++ b/src/controllers/public/quote.controllers.js
@@ -1,4 +1,4 @@
-import quotesJson from "../../json/quotes.json" assert { type: "json" };
+import quotesJson from "../../json/quotes.json" with { type: "json" };
 import { filterObjectKeys, getPaginatedPayload } from "../../utils/helpers.js";
 import { ApiError } from "../../utils/ApiError.js";
 import { ApiResponse } from "../../utils/ApiResponse.js";

--- a/src/controllers/public/randomjoke.controllers.js
+++ b/src/controllers/public/randomjoke.controllers.js
@@ -1,4 +1,4 @@
-import randomJokesJson from "../../json/randomjoke.json" assert { type: "json" };
+import randomJokesJson from "../../json/randomjoke.json" with { type: "json" };
 import { filterObjectKeys, getPaginatedPayload } from "../../utils/helpers.js";
 import { ApiError } from "../../utils/ApiError.js";
 import { ApiResponse } from "../../utils/ApiResponse.js";

--- a/src/controllers/public/randomproduct.controllers.js
+++ b/src/controllers/public/randomproduct.controllers.js
@@ -1,4 +1,4 @@
-import randomProductsJson from "../../json/randomproduct.json" assert { type: "json" };
+import randomProductsJson from "../../json/randomproduct.json" with { type: "json" };
 import { filterObjectKeys, getPaginatedPayload } from "../../utils/helpers.js";
 import { ApiError } from "../../utils/ApiError.js";
 import { ApiResponse } from "../../utils/ApiResponse.js";

--- a/src/controllers/public/randomuser.controllers.js
+++ b/src/controllers/public/randomuser.controllers.js
@@ -1,4 +1,4 @@
-import randomUsersJson from "../../json/randomuser.json" assert { type: "json" };
+import randomUsersJson from "../../json/randomuser.json" with { type: "json" };
 import { filterObjectKeys, getPaginatedPayload } from "../../utils/helpers.js";
 import { ApiError } from "../../utils/ApiError.js";
 import { ApiResponse } from "../../utils/ApiResponse.js";

--- a/src/controllers/public/stock.controllers.js
+++ b/src/controllers/public/stock.controllers.js
@@ -1,4 +1,4 @@
-import nseStocksJson from "../../json/nse-stocks.json" assert { type: "json" };
+import nseStocksJson from "../../json/nse-stocks.json" with { type: "json" };
 import { filterObjectKeys, getPaginatedPayload } from "../../utils/helpers.js";
 import { ApiError } from "../../utils/ApiError.js";
 import { ApiResponse } from "../../utils/ApiResponse.js";

--- a/src/controllers/public/youtube.controllers.js
+++ b/src/controllers/public/youtube.controllers.js
@@ -1,9 +1,9 @@
 import { YouTubeFilterEnum, AvailableYouTubeFilters } from "../../constants.js";
-import channelJson from "../../json/youtube/channel.json" assert { type: "json" };
-import commentsJson from "../../json/youtube/comments.json" assert { type: "json" };
-import playlistItemsJson from "../../json/youtube/playlistitems.json" assert { type: "json" };
-import playlistsJson from "../../json/youtube/playlists.json" assert { type: "json" };
-import videosJson from "../../json/youtube/videos.json" assert { type: "json" };
+import channelJson from "../../json/youtube/channel.json" with { type: "json" };
+import commentsJson from "../../json/youtube/comments.json" with { type: "json" };
+import playlistItemsJson from "../../json/youtube/playlistitems.json" with { type: "json" };
+import playlistsJson from "../../json/youtube/playlists.json" with { type: "json" };
+import videosJson from "../../json/youtube/videos.json" with { type: "json" };
 import { ApiError } from "../../utils/ApiError.js";
 import { ApiResponse } from "../../utils/ApiResponse.js";
 import { asyncHandler } from "../../utils/asyncHandler.js";


### PR DESCRIPTION
the below is the error while using assert keyword with node:latest

![Screenshot from 2024-05-13 21-13-06](https://github.com/hiteshchoudhary/apihub/assets/114758862/75796195-cc6c-445e-9be5-1c350d1baa12)

#148 @wajeshubham The keyword "assert" is used while importing json files , which is only compatible with older versions of node like 18. Newer versions use the keyword "with", in order to assert the type of the file imported.

So I used "with" keyword while importing json files, which works well with newer versions of node.
