### PR TITLE
fix: remove unnecessary return await statements

### DIFF
--- a/examples/apps/ecommerce/web/react-vite-redux-tailwind/src/services/ApiRequest.ts
+++ b/examples/apps/ecommerce/web/react-vite-redux-tailwind/src/services/ApiRequest.ts
@@ -10,7 +10,7 @@ class ApiRequest {
     queryParams: object = {},
     headers: object = {}
   ): Promise<ApiResponse<T> | ApiError> {
-    return await asyncHandler<T>(
+    return asyncHandler<T>(
       (): Promise<AxiosResponse<ApiResponse<T>>> =>
         axios.get<ApiResponse<T>>(this.url, {
           params: queryParams,
@@ -23,7 +23,7 @@ class ApiRequest {
     body: object,
     headers: object = {}
   ): Promise<ApiResponse<T> | ApiError> {
-    return await asyncHandler<T>(
+    return asyncHandler<T>(
       (): Promise<AxiosResponse<ApiResponse<T>>> =>
         axios.post<ApiResponse<T>>(this.url, body, { headers: headers })
     );
@@ -33,7 +33,7 @@ class ApiRequest {
     body: object,
     headers: object = {}
   ): Promise<ApiResponse<T> | ApiError> {
-    return await asyncHandler(
+    return asyncHandler(
       (): Promise<AxiosResponse<ApiResponse<T>>> =>
         axios.put<ApiResponse<T>>(this.url, body, { headers: headers })
     );
@@ -42,7 +42,7 @@ class ApiRequest {
   async deleteRequest<T>(
     headers: object = {}
   ): Promise<ApiResponse<T> | ApiError> {
-    return await asyncHandler(
+    return asyncHandler(
       (): Promise<AxiosResponse<ApiResponse<T>>> =>
         axios.delete<ApiResponse<T>>(this.url, { headers: headers })
     );
@@ -52,7 +52,7 @@ class ApiRequest {
     body: object,
     headers: object = {}
   ): Promise<ApiResponse<T> | ApiError> {
-    return await asyncHandler(
+    return asyncHandler(
       (): Promise<AxiosResponse<ApiResponse<T>>> =>
         axios.patch<ApiResponse<T>>(this.url, body, { headers: headers })
     );

--- a/examples/apps/ecommerce/web/react-vite-redux-tailwind/src/services/CountryApiRequest.ts
+++ b/examples/apps/ecommerce/web/react-vite-redux-tailwind/src/services/CountryApiRequest.ts
@@ -12,7 +12,7 @@ class CountryApiRequest {
     queryParams: object = {},
     headers: object = {}
   ): Promise<ApiResponse<T> | ApiError> {
-    return await countryApiAsyncHandler<T>(
+    return countryApiAsyncHandler<T>(
       (): Promise<AxiosResponse<CountryApiResponse<T>>> =>
         axiosCountryApi.get<CountryApiResponse<T>>(this.url, {
           params: queryParams,
@@ -25,7 +25,7 @@ class CountryApiRequest {
     body: object,
     headers: object = {}
   ): Promise<ApiResponse<T> | ApiError> {
-    return await countryApiAsyncHandler<T>(
+    return countryApiAsyncHandler<T>(
       (): Promise<AxiosResponse<CountryApiResponse<T>>> =>
         axiosCountryApi.post<CountryApiResponse<T>>(this.url, body, {
           headers: headers,
@@ -37,7 +37,7 @@ class CountryApiRequest {
     body: object,
     headers: object = {}
   ): Promise<ApiResponse<T> | ApiError> {
-    return await countryApiAsyncHandler(
+    return countryApiAsyncHandler(
       (): Promise<AxiosResponse<CountryApiResponse<T>>> =>
         axiosCountryApi.put<CountryApiResponse<T>>(this.url, body, {
           headers: headers,
@@ -48,7 +48,7 @@ class CountryApiRequest {
   async deleteRequest<T>(
     headers: object = {}
   ): Promise<ApiResponse<T> | ApiError> {
-    return await countryApiAsyncHandler(
+    return countryApiAsyncHandler(
       (): Promise<AxiosResponse<CountryApiResponse<T>>> =>
         axiosCountryApi.delete<CountryApiResponse<T>>(this.url, {
           headers: headers,
@@ -60,7 +60,7 @@ class CountryApiRequest {
     body: object,
     headers: object = {}
   ): Promise<ApiResponse<T> | ApiError> {
-    return await countryApiAsyncHandler(
+    return countryApiAsyncHandler(
       (): Promise<AxiosResponse<CountryApiResponse<T>>> =>
         axiosCountryApi.patch<CountryApiResponse<T>>(this.url, body, {
           headers: headers,

--- a/src/controllers/apps/auth/user.controllers.js
+++ b/src/controllers/apps/auth/user.controllers.js
@@ -216,7 +216,7 @@ const verifyEmail = asyncHandler(async (req, res) => {
   // Now we can remove the associated email token and expiry date as we no  longer need them
   user.emailVerificationToken = undefined;
   user.emailVerificationExpiry = undefined;
-  // Tun the email verified flag to `true`
+  // Turn the email verified flag to `true`
   user.isEmailVerified = true;
   await user.save({ validateBeforeSave: false });
 

--- a/src/controllers/apps/ecommerce/order.controllers.js
+++ b/src/controllers/apps/ecommerce/order.controllers.js
@@ -120,7 +120,7 @@ const orderFulfillmentHelper = async (orderPaymentId, req) => {
  */
 const paypalApi = async (endpoint, body = {}) => {
   const accessToken = await generatePaypalAccessToken();
-  return await fetch(`${paypalBaseUrl.sandbox}/v2/checkout/orders${endpoint}`, {
+  return fetch(`${paypalBaseUrl.sandbox}/v2/checkout/orders${endpoint}`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/src/models/apps/auth/user.models.js
+++ b/src/models/apps/auth/user.models.js
@@ -114,7 +114,7 @@ userSchema.post("save", async function (user, next) {
 });
 
 userSchema.methods.isPasswordCorrect = async function (password) {
-  return await bcrypt.compare(password, this.password);
+  return bcrypt.compare(password, this.password);
 };
 
 userSchema.methods.generateAccessToken = function () {


### PR DESCRIPTION
There's no need to use await while returning an asynchronous function in JavaScript.

**Previous:**
```js
async function example() {
  return await someAsynchronousFunction();
}
```

**New:**
```js
async function example() {
  return someAsynchronousFunction();
}
```

Both code examples achieve the same result, but the second one is more concise and arguably clearer.