### PR TITLE
fix: replace assert JSON imports with createRequire for compatibility

### DIFF
--- a/src/controllers/kitchen-sink/statuscode.controllers.js
+++ b/src/controllers/kitchen-sink/statuscode.controllers.js
@@ -1,5 +1,8 @@
 import { asyncHandler } from "../../utils/asyncHandler.js";
-import statusCodesJson from "../../json/status-codes.json" assert { type: "json" };
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+
+const statusCodesJson = require("../../json/status-codes.json");
 import { ApiError } from "../../utils/ApiError.js";
 import { ApiResponse } from "../../utils/ApiResponse.js";
 

--- a/src/controllers/public/book.controllers.js
+++ b/src/controllers/public/book.controllers.js
@@ -1,4 +1,6 @@
-import booksJson from "../../json/books.json" assert { type: "json" };
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+const booksJson = require("../../json/books.json");
 import { filterObjectKeys, getPaginatedPayload } from "../../utils/helpers.js";
 import { ApiError } from "../../utils/ApiError.js";
 import { ApiResponse } from "../../utils/ApiResponse.js";

--- a/src/controllers/public/cat.controllers.js
+++ b/src/controllers/public/cat.controllers.js
@@ -1,4 +1,6 @@
-import catsJson from "../../json/cats.json" assert { type: "json" };
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+const catsJson = require("../../json/cats.json");
 import { filterObjectKeys, getPaginatedPayload } from "../../utils/helpers.js";
 import { ApiError } from "../../utils/ApiError.js";
 import { ApiResponse } from "../../utils/ApiResponse.js";

--- a/src/controllers/public/dog.controllers.js
+++ b/src/controllers/public/dog.controllers.js
@@ -1,4 +1,6 @@
-import dogsJson from "../../json/dogs.json" assert { type: "json" };
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+const dogsJson = require("../../json/dogs.json");
 import { filterObjectKeys, getPaginatedPayload } from "../../utils/helpers.js";
 import { ApiError } from "../../utils/ApiError.js";
 import { ApiResponse } from "../../utils/ApiResponse.js";

--- a/src/controllers/public/meal.controllers.js
+++ b/src/controllers/public/meal.controllers.js
@@ -1,4 +1,6 @@
-import mealsJson from "../../json/meals.json" assert { type: "json" };
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+const mealsJson = require("../../json/meals.json");
 import { filterObjectKeys, getPaginatedPayload } from "../../utils/helpers.js";
 import { ApiError } from "../../utils/ApiError.js";
 import { ApiResponse } from "../../utils/ApiResponse.js";

--- a/src/controllers/public/quote.controllers.js
+++ b/src/controllers/public/quote.controllers.js
@@ -1,4 +1,6 @@
-import quotesJson from "../../json/quotes.json" assert { type: "json" };
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+const quotesJson = require("../../json/quotes.json");
 import { filterObjectKeys, getPaginatedPayload } from "../../utils/helpers.js";
 import { ApiError } from "../../utils/ApiError.js";
 import { ApiResponse } from "../../utils/ApiResponse.js";

--- a/src/controllers/public/randomjoke.controllers.js
+++ b/src/controllers/public/randomjoke.controllers.js
@@ -1,4 +1,6 @@
-import randomJokesJson from "../../json/randomjoke.json" assert { type: "json" };
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+const randomJokesJson = require("../../json/randomjoke.json");
 import { filterObjectKeys, getPaginatedPayload } from "../../utils/helpers.js";
 import { ApiError } from "../../utils/ApiError.js";
 import { ApiResponse } from "../../utils/ApiResponse.js";

--- a/src/controllers/public/randomproduct.controllers.js
+++ b/src/controllers/public/randomproduct.controllers.js
@@ -1,4 +1,6 @@
-import randomProductsJson from "../../json/randomproduct.json" assert { type: "json" };
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+const randomProductsJson = require("../../json/randomproduct.json");
 import { filterObjectKeys, getPaginatedPayload } from "../../utils/helpers.js";
 import { ApiError } from "../../utils/ApiError.js";
 import { ApiResponse } from "../../utils/ApiResponse.js";

--- a/src/controllers/public/randomuser.controllers.js
+++ b/src/controllers/public/randomuser.controllers.js
@@ -1,4 +1,6 @@
-import randomUsersJson from "../../json/randomuser.json" assert { type: "json" };
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+const randomUsersJson = require("../../json/randomuser.json");
 import { filterObjectKeys, getPaginatedPayload } from "../../utils/helpers.js";
 import { ApiError } from "../../utils/ApiError.js";
 import { ApiResponse } from "../../utils/ApiResponse.js";

--- a/src/controllers/public/stock.controllers.js
+++ b/src/controllers/public/stock.controllers.js
@@ -1,4 +1,6 @@
-import nseStocksJson from "../../json/nse-stocks.json" assert { type: "json" };
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+const nseStocksJson = require("../../json/nse-stocks.json");
 import { filterObjectKeys, getPaginatedPayload } from "../../utils/helpers.js";
 import { ApiError } from "../../utils/ApiError.js";
 import { ApiResponse } from "../../utils/ApiResponse.js";

--- a/src/controllers/public/youtube.controllers.js
+++ b/src/controllers/public/youtube.controllers.js
@@ -1,9 +1,11 @@
 import { YouTubeFilterEnum, AvailableYouTubeFilters } from "../../constants.js";
-import channelJson from "../../json/youtube/channel.json" assert { type: "json" };
-import commentsJson from "../../json/youtube/comments.json" assert { type: "json" };
-import playlistItemsJson from "../../json/youtube/playlistitems.json" assert { type: "json" };
-import playlistsJson from "../../json/youtube/playlists.json" assert { type: "json" };
-import videosJson from "../../json/youtube/videos.json" assert { type: "json" };
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+const channelJson = require("../../json/youtube/channel.json");
+const commentsJson = require("../../json/youtube/comments.json");
+const playlistItemsJson = require("../../json/youtube/playlistitems.json");
+const playlistsJson = require("../../json/youtube/playlists.json");
+const videosJson = require("../../json/youtube/videos.json");
 import { ApiError } from "../../utils/ApiError.js";
 import { ApiResponse } from "../../utils/ApiResponse.js";
 import { asyncHandler } from "../../utils/asyncHandler.js";


### PR DESCRIPTION
This pull request fixes a compatibility issue with JSON imports in ES modules.
Previously, the project used the following pattern to import .json files:


import data from "./file.json" assert { type: "json" };
While this works in some versions of Node.js with experimental flags, it often fails with the error:


SyntaxError: Unexpected identifier 'assert'
To ensure consistent behavior across environments, all such imports were replaced with:

import { createRequire } from "module";
const require = createRequire(import.meta.url);
const data = require("./file.json");
This approach:

Avoids the need for --experimental-json-modules flag.

Works reliably in ES module projects.

Fixes crashes during app startup (seen in yarn start).

Enhances developer experience and avoids platform-specific behavior.

✅ Changes Made
Replaced all import ... assert { type: "json" } with createRequire()-based imports.

Applied changes across all JSON import files (e.g., books.json, cats.json, status-codes.json, etc.).

Ensured consistent structure with a single createRequire declaration per file.

🧪 Tested
Verified that yarn start runs successfully without crashing.

Confirmed that all JSON data loads correctly and behaves as expected.

@hiteshchoudhary @anirudhuuu @sangamesh1439 @tarun-kavipurapu 

