### PR TITLE
fix(ui): resolve search and GitHub icon overlap in navbar (#304)

### DIFF
--- a/examples/apps/ecommerce/web/react-vite-redux-tailwind/src/components/basic/SearchInput.tsx
+++ b/examples/apps/ecommerce/web/react-vite-redux-tailwind/src/components/basic/SearchInput.tsx
@@ -45,11 +45,11 @@ const SearchInput = (props: SearchInputProps) => {
         type="text"
         placeholder={placeholder}
         dir={`${isRTL ? 'rtl' : 'ltr'}`}
-        className={`flex-1 bg-neutral-100 outline-none text-xs`}
+        className={`flex-1 bg-neutral-100 outline-none text-xs ${isRTL ? 'ml-2' : 'mr-2'}`}
         onChange={onChange}
         onBlur={onBlur}
       />
-      <button type="submit">
+      <button type="submit" className="flex-shrink-0">
         <SearchIcon className="w-6 h-6 text-black" />
       </button>
     </form>


### PR DESCRIPTION
Fix: Search button overlapping GitHub icon
Problem

The search element overlaps the GitHub icon when focused/clicked, causing layout issues and poor user experience.

Solution

Adjusted navbar layout spacing

Improved flex alignment

Prevented unintended overlap during focus state

Testing

Tested on Chrome (Windows 11)

Verified responsive layout

Confirmed no overlap on interaction

Closes #304