### PR TITLE
fix: handle req.files undefined to prevent crash when no images uploaded

### DIFF
--- a/src/controllers/apps/social-media/post.controllers.js
+++ b/src/controllers/apps/social-media/post.controllers.js
@@ -141,14 +141,13 @@ const createPost = asyncHandler(async (req, res) => {
   /**
    * @type {{ url: string; localPath: string; }[]}
    */
-  const images =
-    req.files.images && req.files.images?.length
-      ? req.files.images.map((image) => {
-          const imageUrl = getStaticFilePath(req, image.filename);
-          const imageLocalPath = getLocalPath(image.filename);
-          return { url: imageUrl, localPath: imageLocalPath };
-        })
-      : [];
+  const images = req.files?.images?.length
+    ? req.files.images.map((image) => {
+        const imageUrl = getStaticFilePath(req, image.filename);
+        const imageLocalPath = getLocalPath(image.filename);
+        return { url: imageUrl, localPath: imageLocalPath };
+      })
+    : [];
 
   const author = req.user._id;
 


### PR DESCRIPTION
## Fix: Prevent crash when req.files is undefined

### Problem
Creating a post without images can cause:
"Cannot read properties of undefined (reading 'images')"

This happened because req.files was undefined when no files were uploaded.

<img width="1910" height="1014" alt="Screenshot 2026-04-01 010706" src="https://github.com/user-attachments/assets/e84f51fc-923d-44f4-b2ec-15eb405decd8" />
<img width="805" height="618" alt="Screenshot 2026-04-01 004003" src="https://github.com/user-attachments/assets/bfc55eac-e97a-497c-92a9-477ed0b4a5f3" />


### Solution
Added optional chaining (req.files?.images?.length) to safely handle cases where no images are provided.