### PR TITLE
Security: Open Redirect Vulnerability in Redirect Endpoint

### DIFF
--- a/src/controllers/kitchen-sink/redirect.controllers.js
+++ b/src/controllers/kitchen-sink/redirect.controllers.js
@@ -3,7 +3,22 @@ import { asyncHandler } from "../../utils/asyncHandler.js";
 const redirectToTheUrl = asyncHandler(async (req, res) => {
   const { url } = req.query;
 
-  return res.status(301).redirect(url);
+  if (!url) {
+    return res.status(400).json({ error: "URL is required" });
+  }
+
+  try {
+    const parsedUrl = new URL(url);
+    const allowedDomains = ["localhost", "127.0.0.1"];
+
+    if (!allowedDomains.includes(parsedUrl.hostname)) {
+      return res.status(400).json({ error: "Invalid redirect URL" });
+    }
+
+    return res.status(301).redirect(url);
+  } catch (error) {
+    return res.status(400).json({ error: "Invalid URL format" });
+  }
 });
 
 export { redirectToTheUrl };


### PR DESCRIPTION
## Problem

The redirect endpoint at src/controllers/kitchen-sink/redirect.controllers.js allows arbitrary URL redirection. While there is a validator using isURL(), this validation can be bypassed with certain URL formats (e.g., data: URLs, javascript: URLs, or other protocols). An attacker could craft a malicious URL to redirect users to phishing sites.

**Severity**: `high`
**File**: `src/controllers/kitchen-sink/redirect.controllers.js`

## Solution

Implement a whitelist of allowed domains or use a URL parsing library to validate and restrict redirects to internal domains only. Consider using a function like: const allowedDomains = ['example.com', 'localhost']; const parsedUrl = new URL(url); if (!allowedDomains.includes(parsedUrl.hostname)) return res.status(400).json({error: 'Invalid redirect URL'});

## Changes

- `src/controllers/kitchen-sink/redirect.controllers.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
