### PR TITLE
Security: Arbitrary Cookie Setting Vulnerability

### DIFF
--- a/src/controllers/kitchen-sink/cookie.controllers.js
+++ b/src/controllers/kitchen-sink/cookie.controllers.js
@@ -1,6 +1,21 @@
 import { ApiResponse } from "../../utils/ApiResponse.js";
 import { asyncHandler } from "../../utils/asyncHandler.js";
 
+const ALLOWED_COOKIES = ["theme", "language", "preferences", "sessionId"];
+
+const sanitizeCookieValue = (value) => {
+  if (typeof value !== "string") return String(value);
+  return value.replace(/[<>"'%;()&+]/g, "");
+};
+
+const validateAndPrepareCookie = (key, value) => {
+  if (!ALLOWED_COOKIES.includes(key)) {
+    return null;
+  }
+  const sanitizedValue = sanitizeCookieValue(value);
+  return { key, value: sanitizedValue, options: { httpOnly: true, secure: true, sameSite: "strict" } };
+};
+
 const getCookies = asyncHandler(async (req, res) => {
   return res
     .status(200)
@@ -9,17 +24,28 @@ const getCookies = asyncHandler(async (req, res) => {
 
 const setCookie = asyncHandler(async (req, res) => {
   const cookieObject = req.body;
+  const validCookies = {};
 
-  Object.entries(cookieObject).forEach((entry) => {
-    res.cookie(...entry);
-  });
+  for (const [key, value] of Object.entries(cookieObject)) {
+    const validated = validateAndPrepareCookie(key, value);
+    if (validated) {
+      res.cookie(validated.key, validated.value, validated.options);
+      validCookies[key] = value;
+    }
+  }
+
+  if (Object.keys(validCookies).length === 0) {
+    return res
+      .status(400)
+      .json(new ApiResponse(400, null, "No valid cookies provided"));
+  }
 
   return res
     .status(200)
     .json(
       new ApiResponse(
         200,
-        { cookies: { ...req.cookies, ...cookieObject } },
+        { cookies: { ...req.cookies, ...validCookies } },
         "Cookie has been set"
       )
     );


### PR DESCRIPTION
## Problem

The cookie controller at src/controllers/kitchen-sink/cookie.controllers.js allows setting arbitrary cookies based on user input. The setCookie function iterates over req.body and sets cookies without validation, allowing attackers to set cookies with any name, value, or attributes.

**Severity**: `high`
**File**: `src/controllers/kitchen-sink/cookie.controllers.js`

## Solution

Validate cookie names and values against a strict schema. Only allow specific cookie names and sanitize values. Add HttpOnly, Secure, and SameSite attributes to prevent XSS-based cookie theft.

## Changes

- `src/controllers/kitchen-sink/cookie.controllers.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
